### PR TITLE
Improvements to Error codes changes of #53

### DIFF
--- a/draft-ietf-satp-core.md
+++ b/draft-ietf-satp-core.md
@@ -911,7 +911,7 @@ Here is an example of the message request body:
 The purpose of this message is for the server to indicate explicit
 rejection of the previous message received from the client.
 This message can be sent at any time in the session.
-The server MUST include error details using the Problem Details format defined in {{RFC9457}} (see {{error-types-section}}).
+The server MUST include error details using the Problem Details format defined in {{RFC9457}} (see {{satp-protocol-errors-section}}).
 A reject message is taken to mean an immediate termination of the session.
 
 The message must be signed by the server.
@@ -930,11 +930,11 @@ This should assist in diagnosing problems when different versions of the standar
 - hashPrevMessage REQUIRED: The cryptographic hash of the last message that caused the rejection to occur. The default hash algorithm is SHA256.
 
 - type REQUIRED: A URI reference identifying the error type causing the rejection, as defined in {{RFC9457}}. MUST be a URN of the form
-`urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{error-types-section}}).
+`urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
 
-- status REQUIRED: The HTTP status code for this error as an integer, as defined in {{RFC9457}}. MUST match the HTTP response status and be consistent with the HTTP Status column of the SATP Error Codes Registry ({{error-types-section}}).
+- status REQUIRED: The HTTP status code for this error as an integer, as defined in {{RFC9457}}. MUST match the HTTP response status and be consistent with the HTTP Status column of the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
 
-- title REQUIRED: A short, human-readable summary of the error type, as defined in {{RFC9457}}. SHOULD correspond to the Description column in the SATP Error Codes Registry ({{error-types-section}}).
+- title REQUIRED: A short, human-readable summary of the error type, as defined in {{RFC9457}}. SHOULD correspond to the Description column in the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
 
 - timestamp REQUIRED: timestamp of this message.
 
@@ -1348,11 +1348,11 @@ SATP error messages MUST be encoded as Problem Details objects as defined in {{R
 
 - priorMsgType OPTIONAL: The message type of the previous SATP message that triggered the error. This is a SATP-specific extension field (see {{RFC9457}}).
 
-- type REQUIRED: A URI reference identifying the error type, as defined in {{RFC9457}}. MUST be a URN of the form `urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{error-types-section}}).
+- type REQUIRED: A URI reference identifying the error type, as defined in {{RFC9457}}. MUST be a URN of the form `urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
 
-- status REQUIRED: The HTTP status code for this error as an integer, as defined in {{RFC9457}}. MUST match the HTTP response status and be consistent with the HTTP Status column of the SATP Error Codes Registry ({{error-types-section}}).
+- status REQUIRED: The HTTP status code for this error as an integer, as defined in {{RFC9457}}. MUST match the HTTP response status and be consistent with the HTTP Status column of the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
 
-- title REQUIRED: A short, human-readable summary of the error type, as defined in {{RFC9457}}. SHOULD correspond to the Description column in the SATP Error Codes Registry ({{error-types-section}}).
+- title REQUIRED: A short, human-readable summary of the error type, as defined in {{RFC9457}}. SHOULD correspond to the Description column in the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
 
 - detail OPTIONAL: A human-readable explanation specific to this occurrence of the error, as defined in {{RFC9457}}.
 
@@ -1361,7 +1361,7 @@ SATP error messages MUST be encoded as Problem Details objects as defined in {{R
 
 - instance OPTIONAL: A URI reference identifying the specific occurrence of the error, as defined in {{RFC9457}}. If supplied, it MUST contain the transferContextId.
 
-Further discussion on protocol errors can be found in the SATP Error Codes Registry ({{error-types-section}}).
+Further discussion on protocol errors can be found in the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
 
 ## Session abort message
 
@@ -1423,62 +1423,14 @@ Errors may occur at the connection layer, independent of the flows at the SATP l
 Connection errors resulting in the time-out of the session MUST result in the termination of the transfer session.
 In the case of a transfer session termination, gateways SHOULD release its local computing resources and release asset-locks in their respective networks.
 
-
+error-codes-section
 
 ## SATP Protocol Errors
 
 {: #satp-protocol-errors-section}
 
-The errors at the SATP level pertain to protocol flow and the information carried within each message. These are enumerated in the SATP Error Codes Registry ({{error-types-section}}).
-
-## Effectiveness of Session Aborts
-
-{: #satp-abort-effectiveness-section}
-
-The effectiveness of a session-abort message on the state of the asset depends on where the abort message occurs in the SATP protocol flow in Figure 2.
-
-Note that a session-abort message maybe lost and never be received by the peer gateway. Gateways can crash prior to receiving an abort message.
-
-If gateway G2 transmits a session-abort message after gateway G1 performs a lock (msgtype:lock-assert-msg) on the asset in network NW1, the gateway G1 can always unlock the asset and restore its state.
-
-If either gateway G1 or gateway G2 transmits a session-abort message after gateway G1 sends a lock-assert message (msgtype:lock-assert-msg) but before G2 sends the commit ready message (msgtype:commit-ready-msg), the gateway G1 can always unlock the asset and restore its state in network NW1.
-
-Similarly, if either gateway G1 or gateway G2 transmits a session-abort message immediately after gateway G1 sends a commit-prepare message (msgtype:commit-prepare-msg) but before G2 sends the commit ready message (msgtype:commit-ready-msg), the gateway G2 can always reverse the changes made by G2 to NW2 (i.e. reverse the assignment-to-self of the minted asset).
-
-However, an abort message (occurring in either direction) after gateway G1 transmits the commit final message (msgtype:commit-final-msg) will not be effective. This is because G1 has already burned the asset in NW1 and G2 has already minted the asset in NW2 and has legally agreed to assign the asset to the appropriate beneficiary in NW2.
-
-In general, the termination of sessions or aborts occurring before the sender gateway G1 disables (burns) the asset in NW1 (in flow 3.4 in Figure 2) will incur a minimal cost in terms of computing resources or fees on the part of both gateways G1 and G2.
-
-
-# Security Consideration
-
-{: #satp-Security-Consideration-section}
-
-Gateways may be of interest to attackers because they enable the transferal of digital assets across networks and therefore are an important function in the digital economy.
-
-- Disruptions in transfers and denial of service: Disruptions to a transfer session may cause not only resource waste (e.g. CPU usage), but in some cases may result in financial loss on the part of the gateway operator (e.g. fees charged by network). Denial-of-service attacks by third parties to a run of the protocol may result in the termination of the current run (e.g. time-outs at the SATP layer), and for new attempts to be conducted.
-
-- Dishonest gateways: The SATP protocol requires gateways to sign messages related to the transfer layer, not only to provide message source authentication and integrity but also to maintain honesty on the part of the gateways. Gateway-operators may take-on legal and financial liabilities in certain jurisdictions by digitally signing messages. Dishonest gateways may intentionally delay the delivery of certain messages or intentionally fail (abort) the protocol run at certain crucial points [ARCH].  Two such crucial points in the message flows are the following: (i) the commit-final-msg, where the sender G1 asserts it has extinguished (burned) the asset in the origin network, and (ii) the ack-prepare-msg where the receiver gateway G2 asserts it is ready to proceed with the final commitment. If gateway G1 intentionally drops the commit-final-msg (commit-final) such that gateway G2 times-out, then G2 may suffer financial loss due to roll-back costs in network NW2. Similarly, if G2 intentionally drops the ack-prepare-msg to signal that it is ready to proceed with the commitment (commit-ready), then gateway G1 may time-out and terminate the protocol run, causing resource waste at G1. Operators of gateways should utlize relevant tools to detect possible dishonest behavior of certain gateways, and select to have their gateways peer with other reliable gateways.
-
-- Protection of gateway keys: It is crucial to protect the cryptographic keys utilized by gateways. This includes keys for secure session establishment (TLS1.3) and keys utilized for signing SATP messages. Loss of gateway keys may incur financial loss on the part of the gateway-operator. Implementation of gateways should consider utilizing tamper-resistant hardware to store and manage the relevant keys for gateways operational functions.
-
-- Gateway identification: Mechanisms must be utilized to provide unique identifiers to gateway implementations to ensure global uniqueness and reachability. Existing identification mechanisms such a X509 certificates [RFC5280] and Verifiable Credentials [W3CVC] may be applied for gateway identification.
-
-- Identification of networks: There needs to be mechanism for gateways to declare or disclose the asset networks it current serves. Combined with strong gateway identification, this allows remote gateways to quickly locate suitable gateways to peer with for the purposes of asset transfers.
-
-
-# IANA Consideration
-
-{: #satp-iana-Consideration}
-
-
-The following request is being made to IANA.
-
-## SATP Error Codes Registry
-
-{: #error-types-section}
-
-This registry defines the error codes used in SATP protocol messages.
+The errors at the SATP level pertain to protocol flow and the information carried within each message. These are enumerated in the SATP Error Codes Registry, 
+{{error-codes-section}}.
 
 Many of the errors due to invalid identifiers (e.g., invalid transferContextId, invalid digitalAssetId) may arise within
 the execution of the SATP protocol because these identifiers depart from those agreed-upon in Transfer Initialization Claim in the transfer proposal message.
@@ -1486,6 +1438,10 @@ The validity of these identifiers must be verified by the gateways during set-up
 See Section 7 on the Identity and Asset Verification Stage.
 
 SATP error messages MUST be encoded as Problem Details objects as defined in {{RFC9457}}, with content type `application/problem+json`. The `type` field of the Problem Details object MUST be set to a URN of the form `urn:ietf:params:satp:error:<code>`, where `<code>` is the error code from this registry. The `status` field MUST match the HTTP status of the response carrying the error and MUST be consistent with the HTTP Status column in the table below.
+
+## Protocol Errors Codes
+
+{: #error-codes-section}
 
 In the following table, each entry consists of:
 
@@ -1559,6 +1515,51 @@ In the following table, each entry consists of:
 | err_3.9.2 | Transfer Complete errors | badly formed message | mismatch sessionId | 404 |
 | err_3.9.3 | Transfer Complete errors | badly formed message | mismatch hashPrevMessage | 404 |
 | err_3.9.4 | Transfer Complete errors | badly formed message | mismatch hashTransferCommence | 404 |
+
+## Effectiveness of Session Aborts
+
+{: #satp-abort-effectiveness-section}
+
+The effectiveness of a session-abort message on the state of the asset depends on where the abort message occurs in the SATP protocol flow in Figure 2.
+
+Note that a session-abort message maybe lost and never be received by the peer gateway. Gateways can crash prior to receiving an abort message.
+
+If gateway G2 transmits a session-abort message after gateway G1 performs a lock (msgtype:lock-assert-msg) on the asset in network NW1, the gateway G1 can always unlock the asset and restore its state.
+
+If either gateway G1 or gateway G2 transmits a session-abort message after gateway G1 sends a lock-assert message (msgtype:lock-assert-msg) but before G2 sends the commit ready message (msgtype:commit-ready-msg), the gateway G1 can always unlock the asset and restore its state in network NW1.
+
+Similarly, if either gateway G1 or gateway G2 transmits a session-abort message immediately after gateway G1 sends a commit-prepare message (msgtype:commit-prepare-msg) but before G2 sends the commit ready message (msgtype:commit-ready-msg), the gateway G2 can always reverse the changes made by G2 to NW2 (i.e. reverse the assignment-to-self of the minted asset).
+
+However, an abort message (occurring in either direction) after gateway G1 transmits the commit final message (msgtype:commit-final-msg) will not be effective. This is because G1 has already burned the asset in NW1 and G2 has already minted the asset in NW2 and has legally agreed to assign the asset to the appropriate beneficiary in NW2.
+
+In general, the termination of sessions or aborts occurring before the sender gateway G1 disables (burns) the asset in NW1 (in flow 3.4 in Figure 2) will incur a minimal cost in terms of computing resources or fees on the part of both gateways G1 and G2.
+
+
+# Security Consideration
+
+{: #satp-Security-Consideration-section}
+
+Gateways may be of interest to attackers because they enable the transferal of digital assets across networks and therefore are an important function in the digital economy.
+
+- Disruptions in transfers and denial of service: Disruptions to a transfer session may cause not only resource waste (e.g. CPU usage), but in some cases may result in financial loss on the part of the gateway operator (e.g. fees charged by network). Denial-of-service attacks by third parties to a run of the protocol may result in the termination of the current run (e.g. time-outs at the SATP layer), and for new attempts to be conducted.
+
+- Dishonest gateways: The SATP protocol requires gateways to sign messages related to the transfer layer, not only to provide message source authentication and integrity but also to maintain honesty on the part of the gateways. Gateway-operators may take-on legal and financial liabilities in certain jurisdictions by digitally signing messages. Dishonest gateways may intentionally delay the delivery of certain messages or intentionally fail (abort) the protocol run at certain crucial points [ARCH].  Two such crucial points in the message flows are the following: (i) the commit-final-msg, where the sender G1 asserts it has extinguished (burned) the asset in the origin network, and (ii) the ack-prepare-msg where the receiver gateway G2 asserts it is ready to proceed with the final commitment. If gateway G1 intentionally drops the commit-final-msg (commit-final) such that gateway G2 times-out, then G2 may suffer financial loss due to roll-back costs in network NW2. Similarly, if G2 intentionally drops the ack-prepare-msg to signal that it is ready to proceed with the commitment (commit-ready), then gateway G1 may time-out and terminate the protocol run, causing resource waste at G1. Operators of gateways should utlize relevant tools to detect possible dishonest behavior of certain gateways, and select to have their gateways peer with other reliable gateways.
+
+- Protection of gateway keys: It is crucial to protect the cryptographic keys utilized by gateways. This includes keys for secure session establishment (TLS1.3) and keys utilized for signing SATP messages. Loss of gateway keys may incur financial loss on the part of the gateway-operator. Implementation of gateways should consider utilizing tamper-resistant hardware to store and manage the relevant keys for gateways operational functions.
+
+- Gateway identification: Mechanisms must be utilized to provide unique identifiers to gateway implementations to ensure global uniqueness and reachability. Existing identification mechanisms such a X509 certificates [RFC5280] and Verifiable Credentials [W3CVC] may be applied for gateway identification.
+
+- Identification of networks: There needs to be mechanism for gateways to declare or disclose the asset networks it current serves. Combined with strong gateway identification, this allows remote gateways to quickly locate suitable gateways to peer with for the purposes of asset transfers.
+
+
+# IANA Consideration
+
+{: #satp-iana-Consideration}
+
+
+The following request is being made to IANA.
+
+
 
 ## URN Registration
 
@@ -1648,6 +1649,10 @@ The SATP Message Types registry's initial contents are as follows:
 - Parameter usage location: Session Abort
 - Change controller: IETF
 - Specification document(s): Section 10.7 of draft-ietf-satp-core.
+
+## SATP Error Codes Registry
+
+This specification establishes the SATP Error Codes registry. The purpose of this registry is to define the various error codes utilized in the secure asset transfer protocol (SATP). The errors listed in {{error-codes-section}} are to be registered.
 
 # Acknowledgements
 

--- a/draft-ietf-satp-core.md
+++ b/draft-ietf-satp-core.md
@@ -1492,10 +1492,12 @@ In the following table, each entry consists of:
 
 | Code         | Category                        | Type                  | Description                                  | HTTP Status |
 |--------------|----------------------------------|-----------------------|----------------------------------------------|-------------|
-| err_1.1.1 | Transfer Proposal/Receipt errors | badly formed message | invalid transferContextId | 400 |
-| err_1.1.2 | Transfer Proposal/Receipt errors | badly formed message | invalid sessionId | 400 |
-| err_1.1.3 | Transfer Proposal/Receipt errors | badly formed message | incorrect transferInitClaimFormat | 400 |
-| err_1.1.4 | Transfer Proposal/Receipt errors | badly formed message | bad signature | 400 |
+| err_0.1.1 | General errors | badly formed message | invalid message type | 400 |
+| err_0.1.2 | General errors | authorization error | insufficient permissions | 403 |
+| err_0.1.3 | General errors | badly formed message | bad signature | 422 |
+| err_1.1.1 | Transfer Proposal/Receipt errors | badly formed message | invalid transferContextId | 422 |
+| err_1.1.2 | Transfer Proposal/Receipt errors | badly formed message | invalid sessionId | 422 |
+| err_1.1.3 | Transfer Proposal/Receipt errors | badly formed message | incorrect transferInitClaimFormat | 422 |
 | err_1.1.11 | Transfer Proposal/Receipt errors | badly formed claim | invalid digitalAssetId | 422 |
 | err_1.1.12 | Transfer Proposal/Receipt errors | badly formed claim | invalid assetProfileId | 422 |
 | err_1.1.13 | Transfer Proposal/Receipt errors | badly formed claim | invalid verifiedOriginatorEntityId | 422 |
@@ -1506,64 +1508,52 @@ In the following table, each entry consists of:
 | err_1.1.18 | Transfer Proposal/Receipt errors | badly formed claim | invalid receiverGatewaySignaturePublicKey | 422 |
 | err_1.1.19 | Transfer Proposal/Receipt errors | badly formed claim | invalid senderGatewayId | 422 |
 | err_1.1.20 | Transfer Proposal/Receipt errors | badly formed claim | invalid recipientGatewayId | 422 |
-| err_1.1.31 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported gatewayDefaultSignatureAlgorithm | 422 |
-| err_1.1.32 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported networkLockType | 422 |
-| err_1.1.33 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported networkLockExpirationTime | 422 |
-| err_1.1.34 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported gatewayTlsScheme | 422 |
-| err_1.1.35 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported gatewayLoggingProfile | 422 |
-| err_1.1.36 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported gatewayAccessControlProfile | 422 |
-| err_1.2.1 | Transfer Proposal/Receipt errors | badly formed message | mismatch transferContextId | 400 |
-| err_1.2.2 | Transfer Proposal/Receipt errors | badly formed message | mismatch sessionId | 400 |
-| err_1.2.3 | Transfer Proposal/Receipt errors | badly formed message | mismatch hashTransferInitClaim | 400 |
-| err_1.2.4 | Transfer Proposal/Receipt errors | badly formed message | bad signature | 400 |
-| err_1.3.1 | Transfer Commence errors | badly formed message | mismatch transferContextId | 400 |
-| err_1.3.2 | Transfer Commence errors | badly formed message | mismatch sessionId | 400 |
-| err_1.3.3 | Transfer Commence errors | badly formed message | mismatch hashTransferInitClaim | 400 |
-| err_1.3.4 | Transfer Commence errors | badly formed message | mismatch hashPrevMessage | 400 |
-| err_1.3.5 | Transfer Commence errors | badly formed message | bad signature | 400 |
-| err_1.4.1 | ACK Commence errors | badly formed message | mismatch transferContextId | 400 |
-| err_1.4.2 | ACK Commence errors | badly formed message | mismatch sessionId | 400 |
-| err_1.4.3 | ACK Commence errors | badly formed message | mismatch hashPrevMessage | 400 |
-| err_1.4.4 | ACK Commence errors | badly formed message | bad signature | 400 |
-| err_2.2.1 | Lock Assertion errors | badly formed message | mismatch transferContextId | 400 |
-| err_2.2.2 | Lock Assertion errors | badly formed message | mismatch sessionId | 400 |
-| err_2.2.3 | Lock Assertion errors | badly formed message | unsupported lockAssertionClaimFormat | 400 |
-| err_2.2.4 | Lock Assertion errors | badly formed message | unsupported lockAssertionExpiration | 400 |
-| err_2.2.5 | Lock Assertion errors | badly formed message | mismatch hashPrevMessage | 400 |
-| err_2.2.6 | Lock Assertion errors | badly formed message | bad signature | 400 |
+| err_1.1.31 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported gatewayDefaultSignatureAlgorithm | 415 |
+| err_1.1.32 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported networkLockType | 415 |
+| err_1.1.33 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported networkLockExpirationTime | 415 |
+| err_1.1.34 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported gatewayTlsScheme | 415 |
+| err_1.1.35 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported gatewayLoggingProfile | 415 |
+| err_1.1.36 | Transfer Proposal/Receipt errors | badly formed parameter | unsupported gatewayAccessControlProfile | 415 |
+| err_1.2.1 | Transfer Proposal/Receipt errors | badly formed message | mismatch transferContextId | 404 |
+| err_1.2.2 | Transfer Proposal/Receipt errors | badly formed message | mismatch sessionId | 404 |
+| err_1.2.3 | Transfer Proposal/Receipt errors | badly formed message | mismatch hashTransferInitClaim | 404 |
+| err_1.3.1 | Transfer Commence errors | badly formed message | mismatch transferContextId | 404 |
+| err_1.3.2 | Transfer Commence errors | badly formed message | mismatch sessionId | 404 |
+| err_1.3.3 | Transfer Commence errors | badly formed message | mismatch hashTransferInitClaim | 404 |
+| err_1.3.4 | Transfer Commence errors | badly formed message | mismatch hashPrevMessage | 404 |
+| err_1.4.1 | ACK Commence errors | badly formed message | mismatch transferContextId | 404 |
+| err_1.4.2 | ACK Commence errors | badly formed message | mismatch sessionId | 404 |
+| err_1.4.3 | ACK Commence errors | badly formed message | mismatch hashPrevMessage | 404 |
+| err_2.2.1 | Lock Assertion errors | badly formed message | mismatch transferContextId | 404 |
+| err_2.2.2 | Lock Assertion errors | badly formed message | mismatch sessionId | 404 |
+| err_2.2.3 | Lock Assertion errors | badly formed message | unsupported lockAssertionClaimFormat | 415 |
+| err_2.2.4 | Lock Assertion errors | badly formed message | unsupported lockAssertionExpiration | 415 |
+| err_2.2.5 | Lock Assertion errors | badly formed message | mismatch hashPrevMessage | 404 |
 | err_2.2.7 | Lock Assertion errors | semantic error | asset not found | 404 |
 | err_2.2.8 | Lock Assertion errors | semantic error | asset already locked | 409 |
 | err_2.2.9 | Lock Assertion errors | semantic error | asset lock expired | 410 |
-| err_2.4.1 | Lock Assertion Receipt errors | badly formed message | mismatch transferContextId | 400 |
-| err_2.4.2 | Lock Assertion Receipt errors | badly formed message | mismatch sessionId | 400 |
-| err_2.4.3 | Lock Assertion Receipt errors | badly formed message | mismatch hashPrevMessage | 400 |
-| err_2.4.4 | Lock Assertion Receipt errors | badly formed message | bad signature | 400 |
-| err_3.1.1 | Commit Preparation errors | badly formed message | mismatch transferContextId | 400 |
-| err_3.1.2 | Commit Preparation errors | badly formed message | mismatch sessionId | 400 |
-| err_3.1.3 | Commit Preparation errors | badly formed message | mismatch hashPrevMessage | 400 |
-| err_3.1.4 | Commit Preparation errors | badly formed message | bad signature | 400 |
-| err_3.3.1 | Commit Ready errors | badly formed message | mismatch transferContextId | 400 |
-| err_3.3.2 | Commit Ready errors | badly formed message | mismatch sessionId | 400 |
-| err_3.3.3 | Commit Ready errors | badly formed message | mismatch hashPrevMessage | 400 |
-| err_3.3.4 | Commit Ready errors | badly formed message | unsupported mintAssertionFormat | 400 |
-| err_3.3.5 | Commit Ready errors | badly formed message | bad signature | 400 |
-| err_3.5.1 | Commit Final Assertion errors | badly formed message | mismatch transferContextId | 400 |
-| err_3.5.2 | Commit Final Assertion errors | badly formed message | mismatch sessionId | 400 |
-| err_3.5.3 | Commit Final Assertion errors | badly formed message | mismatch hashPrevMessage | 400 |
-| err_3.5.4 | Commit Final Assertion errors | badly formed message | unsupported burnAssertionClaimFormat | 400 |
-| err_3.5.5 | Commit Final Assertion errors | badly formed message | bad signature | 400 |
-| err_3.7.1 | Commit Final Ack Receipt errors | badly formed message | mismatch transferContextId | 400 |
-| err_3.7.2 | Commit Final Ack Receipt errors | badly formed message | mismatch sessionId | 400 |
-| err_3.7.3 | Commit Final Ack Receipt errors | badly formed message | mismatch hashPrevMessage | 400 |
-| err_3.7.4 | Commit Final Ack Receipt errors | badly formed message | unsupported assignmentAssertionClaimFormat | 400 |
-| err_3.7.5 | Commit Final Ack Receipt errors | badly formed message | bad signature | 400 |
-| err_3.9.1 | Transfer Complete errors | badly formed message | mismatch transferContextId | 400 |
-| err_3.9.2 | Transfer Complete errors | badly formed message | mismatch sessionId | 400 |
-| err_3.9.3 | Transfer Complete errors | badly formed message | mismatch hashPrevMessage | 400 |
-| err_3.9.4 | Transfer Complete errors | badly formed message | mismatch hashTransferCommence | 400 |
-| err_3.9.5 | Transfer Complete errors | badly formed message | bad signature | 400 |
-| err_0.1.1 | General errors | badly formed message | invalid message type | 400 |
-| err_0.1.2 | General errors | authorization error | insufficient permissions | 403 |
+| err_2.4.1 | Lock Assertion Receipt errors | badly formed message | mismatch transferContextId | 404 |
+| err_2.4.2 | Lock Assertion Receipt errors | badly formed message | mismatch sessionId | 404 |
+| err_2.4.3 | Lock Assertion Receipt errors | badly formed message | mismatch hashPrevMessage | 404 |
+| err_3.1.1 | Commit Preparation errors | badly formed message | mismatch transferContextId | 404 |
+| err_3.1.2 | Commit Preparation errors | badly formed message | mismatch sessionId | 404 |
+| err_3.1.3 | Commit Preparation errors | badly formed message | mismatch hashPrevMessage | 404 |
+| err_3.3.1 | Commit Ready errors | badly formed message | mismatch transferContextId | 404 |
+| err_3.3.2 | Commit Ready errors | badly formed message | mismatch sessionId | 404 |
+| err_3.3.3 | Commit Ready errors | badly formed message | mismatch hashPrevMessage | 404 |
+| err_3.3.4 | Commit Ready errors | badly formed message | unsupported mintAssertionFormat | 415 |
+| err_3.5.1 | Commit Final Assertion errors | badly formed message | mismatch transferContextId | 404 |
+| err_3.5.2 | Commit Final Assertion errors | badly formed message | mismatch sessionId | 404 |
+| err_3.5.3 | Commit Final Assertion errors | badly formed message | mismatch hashPrevMessage | 404 |
+| err_3.5.4 | Commit Final Assertion errors | badly formed message | unsupported burnAssertionClaimFormat | 415 |
+| err_3.7.1 | Commit Final Ack Receipt errors | badly formed message | mismatch transferContextId | 404 |
+| err_3.7.2 | Commit Final Ack Receipt errors | badly formed message | mismatch sessionId | 404 |
+| err_3.7.3 | Commit Final Ack Receipt errors | badly formed message | mismatch hashPrevMessage | 404 |
+| err_3.7.4 | Commit Final Ack Receipt errors | badly formed message | unsupported assignmentAssertionClaimFormat | 415 |
+| err_3.9.1 | Transfer Complete errors | badly formed message | mismatch transferContextId | 404 |
+| err_3.9.2 | Transfer Complete errors | badly formed message | mismatch sessionId | 404 |
+| err_3.9.3 | Transfer Complete errors | badly formed message | mismatch hashPrevMessage | 404 |
+| err_3.9.4 | Transfer Complete errors | badly formed message | mismatch hashTransferCommence | 404 |
 
 ## URN Registration
 

--- a/draft-ietf-satp-core.md
+++ b/draft-ietf-satp-core.md
@@ -209,7 +209,7 @@ that this commitment must hold regardless of subsequent
 unavailability (e.g. crash) of the gateways implementing the SATP protocol.
 
 All messages exchanged between gateways are assumed to run over TLS1.3.
-HTTPS/S must be used instead of plain HTTP.
+HTTPS must be used instead of plain HTTP.
 
 The endpoints at the respective gateways should provide access to credentials
 (or other identification mechanisms) to prove the legal owner (or operator) of the gateway.
@@ -451,7 +451,7 @@ The mechanism to allocate globally unique network identifier is outside the scop
 
 
 
-### Transfer-Context ID:
+### Transfer-Context ID
 
 This is the unique immutable identifier representing the application layer context of a single unidirectional transfer. The method to generate the transfer-context ID is outside the scope of the current document.
 
@@ -465,7 +465,7 @@ The mechanism to derive the Transfer Context ID value and to communicate it betw
 
 
 
-### Session ID:
+### Session ID
 
 This is the unique identifier representing a session between two gateways handling a single unidirectional transfer. This may be derived from the Transfer-Context ID at the application level. There may be several session IDs related to a SATP execution instance. Only one Session ID may be active for a given SATP execution instance. Session IDs may be stored in the transfer-context for audit trail purposes.
 
@@ -488,7 +488,7 @@ If the client (sender gateway) transmits a list of supported credential schemes,
 
 If no acceptable credential scheme was offered, a "unsupported
 gatewayTlsScheme" (err_1.1.34) reject message is returned by the server
-{{satp-stage1-init-reject}}.
+(see {{satp-stage1-init-reject}}).
 
 ### Client Offers Other Supported TLS Schemes
 
@@ -1494,7 +1494,7 @@ In the following table, each entry consists of:
 |--------------|----------------------------------|-----------------------|----------------------------------------------|-------------|
 | err_1.1.1 | Transfer Proposal/Receipt errors | badly formed message | invalid transferContextId | 400 |
 | err_1.1.2 | Transfer Proposal/Receipt errors | badly formed message | invalid sessionId | 400 |
-| err_1.1.3 | Transfer Proposal/Receipt errors | badly formed message | incorect transferInitClaimFormat | 400 |
+| err_1.1.3 | Transfer Proposal/Receipt errors | badly formed message | incorrect transferInitClaimFormat | 400 |
 | err_1.1.4 | Transfer Proposal/Receipt errors | badly formed message | bad signature | 400 |
 | err_1.1.11 | Transfer Proposal/Receipt errors | badly formed claim | invalid digitalAssetId | 422 |
 | err_1.1.12 | Transfer Proposal/Receipt errors | badly formed claim | invalid assetProfileId | 422 |

--- a/draft-ietf-satp-core.md
+++ b/draft-ietf-satp-core.md
@@ -918,7 +918,8 @@ The message must be signed by the server.
 
 The parameters of this message consist of the following:
 
-- version REQUIRED: SATP protocol Version see {satp-protocol-version}} as a string "major.minor". This should assist in diagnosing problems when different versions of the standard are used. 
+- version REQUIRED: SATP protocol Version see {satp-protocol-version}} as a string "major.minor".
+This should assist in diagnosing problems when different versions of the standard are used.
 
 - messageType REQUIRED: urn:ietf:satp:msgtype:reject-msg
 

--- a/draft-ietf-satp-core.md
+++ b/draft-ietf-satp-core.md
@@ -918,7 +918,7 @@ The message must be signed by the server.
 
 The parameters of this message consist of the following:
 
-- version REQUIRED: SATP protocol Version see {satp-protocol-version}} as a string "major.minor".
+- version REQUIRED: SATP protocol Version see {satp-protocol-version}} as a string "major.minor". This should assist in diagnosing problems when different versions of the standard are used. 
 
 - messageType REQUIRED: urn:ietf:satp:msgtype:reject-msg
 
@@ -928,7 +928,7 @@ The parameters of this message consist of the following:
 
 - hashPrevMessage REQUIRED: The cryptographic hash of the last message that caused the rejection to occur. The default hash algorithm is SHA256.
 
-- type REQUIRED: A URI reference identifying the error type causing the rejection, as defined in {{RFC9457}}. SHOULD be a URN of the form `urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{error-types-section}}).
+- type REQUIRED: A URI reference identifying the error type causing the rejection, as defined in {{RFC9457}}. MUST be a URN of the form `urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{error-types-section}}).
 
 - status REQUIRED: The HTTP status code for this error as an integer, as defined in {{RFC9457}}. MUST match the HTTP response status and be consistent with the HTTP Status column of the SATP Error Codes Registry ({{error-types-section}}).
 
@@ -1346,7 +1346,7 @@ SATP error messages MUST be encoded as Problem Details objects as defined in {{R
 
 - priorMsgType OPTIONAL: The message type of the previous SATP message that triggered the error. This is a SATP-specific extension field (see {{RFC9457}}).
 
-- type REQUIRED: A URI reference identifying the error type, as defined in {{RFC9457}}. SHOULD be a URN of the form `urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{error-types-section}}).
+- type REQUIRED: A URI reference identifying the error type, as defined in {{RFC9457}}. MUST be a URN of the form `urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{error-types-section}}).
 
 - status REQUIRED: The HTTP status code for this error as an integer, as defined in {{RFC9457}}. MUST match the HTTP response status and be consistent with the HTTP Status column of the SATP Error Codes Registry ({{error-types-section}}).
 
@@ -1354,7 +1354,10 @@ SATP error messages MUST be encoded as Problem Details objects as defined in {{R
 
 - detail OPTIONAL: A human-readable explanation specific to this occurrence of the error, as defined in {{RFC9457}}.
 
-- instance OPTIONAL: A URI reference identifying the specific occurrence of the error, as defined in {{RFC9457}}. MAY be used to convey the transferContextId.
+
+- transferContextId REQUIRED: A unique identifier used to identify the current transfer session at the application layer. Note that the transferContextId is always included, whereas the instance defined in {{RFC9457}} is optional, but if supplied, must also contain the transferContextId. The transferContextId is used in all messages, whereas instance is specific to errror messages.
+
+- instance OPTIONAL: A URI reference identifying the specific occurrence of the error, as defined in {{RFC9457}}. If supplied, it MUST contain the transferContextId.
 
 Further discussion on protocol errors can be found in the SATP Error Codes Registry ({{error-types-section}}).
 
@@ -1480,7 +1483,7 @@ the execution of the SATP protocol because these identifiers depart from those a
 The validity of these identifiers must be verified by the gateways during set-up stage (Stage-0), which is beyond the scope of the current specification.
 See Section 7 on the Identity and Asset Verification Stage.
 
-SATP error messages MUST be encoded as Problem Details objects as defined in {{RFC9457}}, with content type `application/problem+json`. The `type` field of the Problem Details object SHOULD be set to a URN of the form `urn:ietf:params:satp:error:<code>`, where `<code>` is the error code from this registry. The `status` field MUST match the HTTP status of the response carrying the error and MUST be consistent with the HTTP Status column in the table below.
+SATP error messages MUST be encoded as Problem Details objects as defined in {{RFC9457}}, with content type `application/problem+json`. The `type` field of the Problem Details object MUST be set to a URN of the form `urn:ietf:params:satp:error:<code>`, where `<code>` is the error code from this registry. The `status` field MUST match the HTTP status of the response carrying the error and MUST be consistent with the HTTP Status column in the table below.
 
 In the following table, each entry consists of:
 

--- a/draft-ietf-satp-core.md
+++ b/draft-ietf-satp-core.md
@@ -1429,7 +1429,7 @@ error-codes-section
 
 {: #satp-protocol-errors-section}
 
-The errors at the SATP level pertain to protocol flow and the information carried within each message. These are enumerated in the SATP Error Codes Registry, 
+The errors at the SATP level pertain to protocol flow and the information carried within each message. These are enumerated in the SATP Error Codes Registry,
 {{error-codes-section}}.
 
 Many of the errors due to invalid identifiers (e.g., invalid transferContextId, invalid digitalAssetId) may arise within

--- a/draft-ietf-satp-core.md
+++ b/draft-ietf-satp-core.md
@@ -911,46 +911,13 @@ Here is an example of the message request body:
 The purpose of this message is for the server to indicate explicit
 rejection of the previous message received from the client.
 This message can be sent at any time in the session.
-The server MUST include error details using the Problem Details format defined in {{RFC9457}} (see {{satp-protocol-errors-section}}).
-A reject message is taken to mean an immediate termination of the session.
+The server MUST include error details using the Problem Details format defined in {{RFC9457}}
+(see {{satp-protocol-errors-section}}).
 
 The message must be signed by the server.
 
-The parameters of this message consist of the following:
+A reject message is taken to mean an immediate termination of the session.
 
-- version REQUIRED: SATP protocol Version see {satp-protocol-version}} as a string "major.minor".
-This should assist in diagnosing problems when different versions of the standard are used.
-
-- messageType REQUIRED: urn:ietf:satp:msgtype:reject-msg
-
-- sessionId REQUIRED: A unique identifier chosen by the client to identify the current session.
-
-- transferContextId REQUIRED: A unique identifier used to identify the current transfer session at the application layer.
-
-- hashPrevMessage REQUIRED: The cryptographic hash of the last message that caused the rejection to occur. The default hash algorithm is SHA256.
-
-- type REQUIRED: A URI reference identifying the error type causing the rejection, as defined in {{RFC9457}}. MUST be a URN of the form
-`urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
-
-- status REQUIRED: The HTTP status code for this error as an integer, as defined in {{RFC9457}}. MUST match the HTTP response status and be consistent with the HTTP Status column of the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
-
-- title REQUIRED: A short, human-readable summary of the error type, as defined in {{RFC9457}}. SHOULD correspond to the Description column in the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
-
-- timestamp REQUIRED: timestamp of this message.
-
-Here is an example of the message request body:
-
-{\
-  "version": "1.0",\
-  "messageType": "urn:ietf:satp:msgtype:reject-msg",\
-  "sessionId": "d66a567c-11f2-4729-a0e9-17ce1faf47c1",\
-  "transferContextId": "89e04e71-bba2-4363-933c-262f42ec07a0",\
-  "hashPrevMessage": "154dfaf0406038641e7e59509febf41d9d5d80f367db96198690151f4758ca6e",\
-  "type": "urn:ietf:params:satp:error:err_1.1.11",\
-  "status": 422,\
-  "title": "invalid digitalAssetId",\
-  "timestamp": "2024-10-03T12:02+00Z",\
-}\
 
 
 ## Transfer Commence Message
@@ -1340,28 +1307,9 @@ Example:
 
 The purpose of this message is for either the sender or the receiver gateways to indicate to its peer that an error has occurred within the transfer protocol flow.
 
-SATP error messages MUST be encoded as Problem Details objects as defined in {{RFC9457}}, with content type `application/problem+json`. The default action upon receiving an error message is the immediate termination of the session.
+The default action upon receiving an error message is the immediate termination of the session.
 
-- messageType REQUIRED: It MUST be the value urn:ietf:satp:msgtype:error-msg. This is a SATP-specific extension field (see {{RFC9457}}).
-
-- sessionId REQUIRED: This is the current session in which the error pertains. This is a SATP-specific extension field (see {{RFC9457}}).
-
-- priorMsgType OPTIONAL: The message type of the previous SATP message that triggered the error. This is a SATP-specific extension field (see {{RFC9457}}).
-
-- type REQUIRED: A URI reference identifying the error type, as defined in {{RFC9457}}. MUST be a URN of the form `urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
-
-- status REQUIRED: The HTTP status code for this error as an integer, as defined in {{RFC9457}}. MUST match the HTTP response status and be consistent with the HTTP Status column of the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
-
-- title REQUIRED: A short, human-readable summary of the error type, as defined in {{RFC9457}}. SHOULD correspond to the Description column in the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
-
-- detail OPTIONAL: A human-readable explanation specific to this occurrence of the error, as defined in {{RFC9457}}.
-
-
-- transferContextId REQUIRED: A unique identifier used to identify the current transfer session at the application layer. Note that the transferContextId is always included, whereas the instance defined in {{RFC9457}} is optional, but if supplied, must also contain the transferContextId. The transferContextId is used in all messages, whereas instance is specific to errror messages.
-
-- instance OPTIONAL: A URI reference identifying the specific occurrence of the error, as defined in {{RFC9457}}. If supplied, it MUST contain the transferContextId.
-
-Further discussion on protocol errors can be found in the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
+The error message format and parameters are described in {{satp-protocol-errors-section}}.
 
 ## Session abort message
 
@@ -1438,6 +1386,52 @@ The validity of these identifiers must be verified by the gateways during set-up
 See Section 7 on the Identity and Asset Verification Stage.
 
 SATP error messages MUST be encoded as Problem Details objects as defined in {{RFC9457}}, with content type `application/problem+json`. The `type` field of the Problem Details object MUST be set to a URN of the form `urn:ietf:params:satp:error:<code>`, where `<code>` is the error code from this registry. The `status` field MUST match the HTTP status of the response carrying the error and MUST be consistent with the HTTP Status column in the table below.
+
+The parameters of error messages consist of the following:
+
+- messageType REQUIRED: urn:ietf:satp:msgtype:reject-msg
+
+- type REQUIRED: A URI reference identifying the error type causing the rejection, as defined in {{RFC9457}}. MUST be a URN of the form
+`urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
+
+- status REQUIRED: The HTTP status code for this error as an integer, as defined in {{RFC9457}}. MUST match the HTTP response status and be consistent with the HTTP Status column of the protocol error codes ({{error-codes-section}}).
+
+- title REQUIRED: A short, human-readable summary of the error type, as defined in {{RFC9457}}. SHOULD correspond to the Description column in the SATP Error Codes Registry ({{satp-protocol-errors-section}}).
+
+- detail OPTIONAL: A human-readable explanation specific to this occurrence of the error, as defined in {{RFC9457}}.
+
+- version REQUIRED: SATP protocol Version see {satp-protocol-version}} as a string "major.minor".
+This should assist in diagnosing problems when different versions of the standard are used.
+
+- sessionId REQUIRED: A unique identifier chosen by the client to identify the current session.
+
+- transferContextId REQUIRED: A unique identifier used to identify the current transfer session at the application layer. Note that the transferContextId is always included, whereas the instance defined in {{RFC9457}} is optional, but if supplied, must also contain the transferContextId. The transferContextId is used in all messages, whereas instance is specific to errror messages.
+
+- instance OPTIONAL: A URI reference identifying the specific occurrence of the error, as defined in {{RFC9457}}. If supplied, it MUST contain the transferContextId.
+
+- prevMsgType OPTIONAL: The message type of the previous SATP message that triggered the error. This is a SATP-specific extension field (see {{RFC9457}}).
+
+- hashPrevMessage REQUIRED: The cryptographic hash of the last message that caused the rejection to occur. The default hash algorithm is SHA256.
+
+- timestamp REQUIRED: timestamp of this message.
+
+
+Here is an example of the error message body:
+
+{\
+  "messageType": "urn:ietf:satp:msgtype:reject-msg",\
+  "type": "urn:ietf:params:satp:error:err_1.1.11",\
+  "status": 422,\
+  "title": "invalid digitalAssetId",\
+  "version": "1.0",\
+  "sessionId": "d66a567c-11f2-4729-a0e9-17ce1faf47c1",\
+  "transferContextId": "89e04e71-bba2-4363-933c-262f42ec07a0",\
+  "instance": "89e04e71-bba2-4363-933c-262f42ec07a0",\
+  "prevMsgType": "urn:ietf:satp:msgtype:transfer-proposal-msg"
+  "hashPrevMessage": "154dfaf0406038641e7e59509febf41d9d5d80f367db96198690151f4758ca6e",\
+  "timestamp": "2024-10-03T12:02+00Z",\
+}\
+
 
 ## Protocol Errors Codes
 

--- a/draft-ietf-satp-core.md
+++ b/draft-ietf-satp-core.md
@@ -928,7 +928,8 @@ The parameters of this message consist of the following:
 
 - hashPrevMessage REQUIRED: The cryptographic hash of the last message that caused the rejection to occur. The default hash algorithm is SHA256.
 
-- type REQUIRED: A URI reference identifying the error type causing the rejection, as defined in {{RFC9457}}. MUST be a URN of the form `urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{error-types-section}}).
+- type REQUIRED: A URI reference identifying the error type causing the rejection, as defined in {{RFC9457}}. MUST be a URN of the form
+`urn:ietf:params:satp:error:<code>` where `<code>` is the error code from the SATP Error Codes Registry ({{error-types-section}}).
 
 - status REQUIRED: The HTTP status code for this error as an integer, as defined in {{RFC9457}}. MUST match the HTTP response status and be consistent with the HTTP Status column of the SATP Error Codes Registry ({{error-types-section}}).
 


### PR DESCRIPTION
Implementing suggestions in comments of PR https://github.com/ietf-satp/draft-ietf-satp-core/pull/53 .

- status codes of error table
- corrections and clarifications of individual error messages.
- The rearrangement and consolidation of the sections on errors will be forthcoming in a separate PR.